### PR TITLE
Adds PORT variable to gmailClient.py

### DIFF
--- a/src/gmailClient.py
+++ b/src/gmailClient.py
@@ -10,6 +10,7 @@ from google.oauth2.credentials import Credentials
 
 SCOPES = ['https://mail.google.com/']
 APPLICATION_NAME = 'Gmail API Python'
+PORT_URI='8080'
 
 # Deletes all the e-mails sent from a specific adress that us chosen by the user.
   
@@ -38,7 +39,7 @@ class GmailClient:
                 creds.refresh(Request())
             else:
                 flow = InstalledAppFlow.from_client_secrets_file('credentials.json', SCOPES)
-                creds = flow.run_local_server(port=0)
+                creds = flow.run_local_server(port=PORT_URI)
         
             # Save the credentials for the next run
             with open('token.json', 'w') as token:


### PR DESCRIPTION
**TL;DR** -> Proposing adding `PORT_URI` as a variable (set as port 8080 as a default) so that users can properly define the authorized redirect URI in OAuth 2.0 Client Ids. 

#TODO -> Update READEME file with instructions to place the proper port in authorized URI.

When trying to add authorized redirect URI in OAuth 2.0 Client Ids, the connection fails when trying to authenticate because the port number is not defined (or in the code it was just 0). So the authentication throws a 400 error because we have an incorrect redirect URI. As the code was defined before, the port would just switch through random ports, so I am proposing adding a global variable `PORT_URI` set to `8080` as default that a user can define so that he or she may know what port to use in Google Cloud OAuth 2.0 authorized redirect URIs. This should be added to the README instructions as well. Thank you.