### PR TITLE
Fixes option 7 for permanent trash deletion updating gmailMethods.py

### DIFF
--- a/src/gmailMethods.py
+++ b/src/gmailMethods.py
@@ -180,7 +180,7 @@ class GmailMethod:
 
 			while 'nextPageToken' in response:
 				page_token = response['nextPageToken']
-				response = self.google_client.service.users().messages().list(
+				response = self.gmailclient.service.users().messages().list(
 				    userId="me", labelIds=label_Id, pageToken=page_token).execute()
 				if 'messages' in response:
 					for message in response['messages']:


### PR DESCRIPTION
**TL;DR** CLI crashes when choosing option 7 caused by wrong attribute in method. 

Changes `self.google_client.service.users().messages()` to `self.gmailclient.service.users().messages()` that lead to app crash.